### PR TITLE
Simplify iframe src url building

### DIFF
--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,7 +1,6 @@
 module.exports = function(media, options) {
-  
   let out = `<div id="spotify-${media.type}-${media.id}" class="${options.embedClass} ${options.embedClass}-${media.type}">`;
-  out += `<iframe src="https://open.spotify.com/embed/${media.type === 'userplaylist' ? 'user/spotify/playlist' : media.type}/${media.id}" `;
+  out += `<iframe src="https://open.spotify.com/embed/${media.type}/${media.id}" `;
   out += `width="${options.width}" height="${options.height}" `
   out += `frameborder="0" allowtransparency="true" allow="${options.allowAttrs}"></iframe>`;
   out += `</div>`;


### PR DESCRIPTION
In an earlier version of the [Spotify embed](https://developer.spotify.com/documentation/widgets/generate/play-button/), the iframe src URL was slightly different if the playlist had been generated by Spotify, compared to created by an ordinary user. Sometime since the last release that's changed, and so we don't need to catch Spotify-generated playlists to generate the iframe markup anymore.

This PR removes the ternary operator and just dumps the `media.type` as part of the iframe src.