### PR TITLE
Support podcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ Edit any of the [default values](lib/pluginDefaults.js) in this options object t
 The plugin supports common Spotify URL variants as well. These should also work in your Markdown files.:
 
 ```markdown
-<!-- Works with individual tracks, albums, artists, and playlists: -->
+<!-- Works with individual tracks, albums, artists, podcast episodes, and playlists: -->
 
 https://open.spotify.com/track/7nJZ9LplJ3ZAyhQyJCJk0K
 https://open.spotify.com/album/2PjlaxlMunGOUvcRzlTbtE
 https://open.spotify.com/artist/6ueGR6SWhUJfvEhqkvMsVs
+https://open.spotify.com/episode/7G5O2wWmch1ciYDPZS4a4O
 
 <!-- Playlists work with or without usernames: -->
 
@@ -129,3 +130,4 @@ If you run across a URL pattern that you think should work, but doesn’t, pleas
 - I’ve tried to accommodate common variants, but there are conceivably valid Spotify URLs that wouldn’t get recognized. Please [file an issue](https://github.com/gfscott/eleventy-plugin-embed-spotify/issues/new) if you run into an edge case!
 - This plugin uses [transforms](https://www.11ty.dev/docs/config/#transforms), so it alters Eleventy’s HTML output as it’s generated. It doesn’t alter the source Markdown.
 - The embedded player is not responsive by default. Spotify’s default player is 300 pixels wide by 380 pixels tall.
+- **New in 1.1.0:** The embedded podcast player _is_ responsive, in keeping with Spotify’s defaults. Currently, all podcast episode players will be 232 pixels tall, with 100% width.

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,7 +1,7 @@
 module.exports = function(media, options) {
   let out = `<div id="spotify-${media.type}-${media.id}" class="${options.embedClass} ${options.embedClass}-${media.type}">`;
   out += `<iframe src="https://open.spotify.com/embed/${media.type}/${media.id}" `;
-  out += `width="${options.width}" height="${options.height}" `
+  out += `width="${ media.type === 'episode' ? '100%' : options.width}" height="${ media.type === 'episode' ? '232' : options.height}" `
   out += `frameborder="0" allowtransparency="true" allow="${options.allowAttrs}"></iframe>`;
   out += `</div>`;
   return out;

--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,6 +1,6 @@
 module.exports = function(media, options) {
   let out = `<div id="spotify-${media.type}-${media.id}" class="${options.embedClass} ${options.embedClass}-${media.type}">`;
-  out += `<iframe src="https://open.spotify.com/embed/${media.type}/${media.id}" `;
+  out += `<iframe src="https://open.spotify.com/embed${ media.type === 'episode' ? '-podcast' : ''}/${media.type}/${media.id}" `;
   out += `width="${ media.type === 'episode' ? '100%' : options.width}" height="${ media.type === 'episode' ? '232' : options.height}" `
   out += `frameborder="0" allowtransparency="true" allow="${options.allowAttrs}"></iframe>`;
   out += `</div>`;

--- a/lib/extractMatches.js
+++ b/lib/extractMatches.js
@@ -1,4 +1,4 @@
-const thisPattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?)?(?::?\/\/)?(?:open\.|www\.)?(?:spotify\.com)\/(?:user)?\/?(?:[0-9a-zA-Z]+)?\/?(playlist|track|album|artist)\/([0-9a-zA-Z]{22})(?:\S*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/;
+const thisPattern = /<p>(?:\s*)(?:<a(?:.*)>)?(?:\s*)(?:https?)?(?::?\/\/)?(?:open\.|www\.)?(?:spotify\.com)\/(?:user)?\/?(?:[0-9a-zA-Z]+)?\/?(playlist|track|album|artist|episode)\/([0-9a-zA-Z]{22})(?:\S*)(?:\s*)(?:<\/a>)?(?:\s*)<\/p>/;
 
 module.exports = function(str) {
   // empty [0] value: full pattern match is returned as the first array item, but it's not used

--- a/lib/spotPattern.js
+++ b/lib/spotPattern.js
@@ -1,4 +1,4 @@
-const pattern = /<p>\s*(?:<a.*>)?\s*(?:https?)?(?::?\/\/)?(?:open\.|www\.)?spotify\.com\/(?:user)?\/?(?:[0-9a-zA-Z]+)?\/?(?:playlist|track|album|artist)\/[0-9a-zA-Z]{22}\S*\s*(?:<\/a>)?\s*<\/p>/g;
+const pattern = /<p>\s*(?:<a.*>)?\s*(?:https?)?(?::?\/\/)?(?:open\.|www\.)?spotify\.com\/(?:user)?\/?(?:[0-9a-zA-Z]+)?\/?(?:playlist|track|album|artist|episode)\/[0-9a-zA-Z]{22}\S*\s*(?:<\/a>)?\s*<\/p>/g;
 
 module.exports = function(str) {
   return str.match(pattern);

--- a/test.js
+++ b/test.js
@@ -10,6 +10,7 @@ const validStrings = [
   {type: 'Playlist', str: 'spotify.com/playlist/7zv2xFPTH1MBynYafuvtCj'},
   {type: 'Playlist with user ID', str: 'spotify.com/user/gfscott/playlist/7zv2xFPTH1MBynYafuvtCj'},
   {type: 'Track', str: 'spotify.com/track/3gsCAGsWr6pUm1Vy7CPPob'},
+  {type: 'Podcast episode', str: 'spotify.com/episode/7G5O2wWmch1ciYDPZS4a4O'},
 ]
 
 const invalidStrings = [


### PR DESCRIPTION
Close #1 

This PR adds support for embedding individual Spotify podcast episodes. Currently, podcast episodes will always be embedded at a fixed height and 100% width, which is how Spotify's own [embed-building utility](https://developer.spotify.com/documentation/widgets/generate/play-button/) treats them. This overrides any user-specified height and width values, but only for podcasts.

I'm going to investigate more about embedding a `show` before adding that feature, although it's technically feasible.