### PR TITLE
Add title attribute to iframe for better accessibility

### DIFF
--- a/lib/buildEmbed.js
+++ b/lib/buildEmbed.js
@@ -1,6 +1,6 @@
 module.exports = function(media, options) {
   let out = `<div id="spotify-${media.type}-${media.id}" class="${options.embedClass} ${options.embedClass}-${media.type}">`;
-  out += `<iframe src="https://open.spotify.com/embed${ media.type === 'episode' ? '-podcast' : ''}/${media.type}/${media.id}" `;
+  out += `<iframe title="${media.type} on Spotify" src="https://open.spotify.com/embed${ media.type === 'episode' ? '-podcast' : ''}/${media.type}/${media.id}" `;
   out += `width="${ media.type === 'episode' ? '100%' : options.width}" height="${ media.type === 'episode' ? '232' : options.height}" `
   out += `frameborder="0" allowtransparency="true" allow="${options.allowAttrs}"></iframe>`;
   out += `</div>`;


### PR DESCRIPTION
Thanks for the great plugin! 🎉 

When running a Chrome Lighthouse audit on a page using this plugin, I noticed the warning `<frame> or <iframe> elements do not have a title`:

![image](https://user-images.githubusercontent.com/3902488/84601009-f3d33080-ae42-11ea-8ff5-67ab421219c3.png)

According to the [WebAIM guide for iframes](https://webaim.org/techniques/frames/#iframe):

> a descriptive title attribute value is not necessary for accessibility. If the inline frame presents content as a whole that is visually distinctive, such as an advertisement or video player, then a title should be provided to indicate this distinction.

This PR adds a simple `title` attribute to the Spotify embeds that specifies the Spotify media type and indicates the iframe content is "on Spotify." I _think_ this should be a sufficient description to consider this an accessibility improvement.

Thanks for considering this addition!